### PR TITLE
Fix timeout attribute

### DIFF
--- a/src/modules/config.py
+++ b/src/modules/config.py
@@ -20,7 +20,7 @@ class Config:
             self.port = 1238            # port of server
         if not hasattr(self, 'freq'):
             self.freq = 20              # [Hz] update rate
-        if not hasattr(self, 'time out of driving robot'):
+        if not hasattr(self, 'timeOutDR'):
             self.timeOutDR = 1            # [s] elapsed time until test is interrupted
 
         # variables AK communication
@@ -55,7 +55,7 @@ class Config:
                         case 'update frequency':
                             self.freq = item[idxStr:idxEnd]
                         case 'time out of driving robot':
-                            self.timeOut = item[idxStr:idxEnd]
+                            self.timeOutDR = item[idxStr:idxEnd]
                         case 'transformation':
                             self.ENU2Local = float(item[idxStr:idxEnd])
                 except:


### PR DESCRIPTION
## Summary
- fix attribute check for driving robot timeout
- store timeout consistently in config parser

## Testing
- `python -m py_compile src/modules/config.py`
- `python -m py_compile src/modules/*.py`


------
https://chatgpt.com/codex/tasks/task_e_687bf1fe30e08321bb21a60ce6fc2e2b